### PR TITLE
fix: wallpaper settings

### DIFF
--- a/ovos_gui_plugin_shell_companion/__init__.py
+++ b/ovos_gui_plugin_shell_companion/__init__.py
@@ -145,7 +145,7 @@ class OVOSShellCompanionExtension(GUIExtension):
 
     def handle_device_wallpaper_settings(self, message):
         self.gui['state'] = 'settings/wallpaper_settings'
-        self.gui.show_page("SYSTEM_AdditionalSettings.qml", override_idle=True)
+        self.gui.show_page("AdditionalSettings", override_idle=True)
 
     def handle_device_about_page(self, message):
         # TODO: Move `system_information` generation to util method

--- a/ovos_gui_plugin_shell_companion/__init__.py
+++ b/ovos_gui_plugin_shell_companion/__init__.py
@@ -69,6 +69,7 @@ class OVOSShellCompanionExtension(GUIExtension):
         self.gui.register_handler("mycroft.device.settings.about.page", self.handle_device_about_page)
         self.gui.register_handler("mycroft.device.settings.display", self.handle_device_display_settings)
         self.gui.register_handler("mycroft.device.settings.factory", self.handle_device_display_factory)
+        self.gui.register_handler("mycroft.device.settings.wallpapers", self.handle_device_wallpaper_settings)
 
         # Display settings
         self.gui.register_handler("speaker.extension.display.set.auto.dim",
@@ -141,6 +142,10 @@ class OVOSShellCompanionExtension(GUIExtension):
         self.gui['display_auto_dim'] = self.config.get("auto_dim", False)
         self.gui['display_auto_nightmode'] = self.config.get("auto_nightmode", False)
         self.gui.show_page("AdditionalSettings", override_idle=True)
+
+    def handle_device_wallpaper_settings(self, message):
+        self.gui['state'] = 'settings/wallpaper_settings'
+        self.gui.show_page("SYSTEM_AdditionalSettings.qml", override_idle=True)
 
     def handle_device_about_page(self, message):
         # TODO: Move `system_information` generation to util method

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ovos-plugin-manager>=0.5.5,<1.0.0
 ovos-utils>=0.0.34,<1.0.0
-ovos-bus-client>=0.0.3,<1.0.0
+ovos-bus-client>=0.0.8,<2.0.0
 astral~=3.0


### PR DESCRIPTION
closes https://github.com/OpenVoiceOS/ovos-gui-plugin-shell-companion/issues/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new wallpaper settings page within the application.
	- Added functionality to handle wallpaper settings through the GUI.

- **Chores**
	- Updated the version constraint for the `ovos-bus-client` dependency to ensure compatibility with newer features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->